### PR TITLE
Use libxmljs for XmlLoader XML parsing and updating

### DIFF
--- a/lib/XmlLoader.js
+++ b/lib/XmlLoader.js
@@ -8,7 +8,7 @@ let util = require('util'),
     fs = require("fs"),
     Err = require('@kartotherian/err'),
     checkType = require('@kartotherian/input-validator'),
-    xmldoc = require('xmldoc');
+    libxmljs = require('libxmljs');
 
 Promise.promisifyAll(fs);
 
@@ -74,23 +74,22 @@ XmlLoader.prototype.update = function update(xmlData, xmlFile) {
     ) {
         return xmlData;
     }
-
-    let doc = new xmldoc.XmlDocument(xmlData);
+    let doc = libxmljs.parseXmlString(xmlData, { noblanks: true });
 
     // 'xmlSetAttrs' overrides root attributes. Usage:
     //    xmlSetAttrs: { 'font-directory': 'string' }
     if (checkType(opts, 'xmlSetAttrs', 'object')) {
-        self._setXmlAttributes(opts.xmlSetAttrs, doc);
+        self._setXmlAttributes(opts.xmlSetAttrs, doc.root());
     }
 
     // 'xmlSetParams' overrides root parameter values. Usage:
     //    xmlSetParams: { 'maxzoom': 20, 'source': {'ref':'v1gen'} }
     if (checkType(opts, 'xmlSetParams', 'object')) {
-        let xmlParams = doc.childNamed('Parameters');
+        let xmlParams = doc.root().get('Parameters');
         if (!xmlParams) {
             throw new Err('<Parameters> xml element was not found in %j', xmlFile);
         }
-        self._setXmlParameters(opts.xmlSetParams, xmlParams, xmlFile);
+        self._setXmlParameters(doc, opts.xmlSetParams, xmlParams, xmlFile);
     }
 
     // 'xmlLayers' selects just the layers specified by a list (could be a single string)
@@ -99,13 +98,11 @@ XmlLoader.prototype.update = function update(xmlData, xmlFile) {
     //    layers: ['waterway', 'building']
     let layerFunc = getLayerFilter(opts);
     if (layerFunc) {
-        let result = [];
-        doc.eachChild(xmlChild => {
-            if (xmlChild.name !== 'Layer' || layerFunc(xmlChild)) {
-                result.push(xmlChild);
+        doc.childNodes().forEach(xmlChild => {
+            if (xmlChild.name() === 'Layer' && !layerFunc(xmlChild)) {
+                xmlChild.remove();
             }
         });
-        doc.children = result;
     }
 
     // 'xmlSetDataSource' allows alterations to the datasource parameters in each layer.
@@ -127,25 +124,25 @@ XmlLoader.prototype.update = function update(xmlData, xmlFile) {
                 conditions = _.mapObject(ds.if, (value, key) => self._resolveValue(value, key));
             }
             doc.eachChild(xmlLayer => {
-                if (xmlLayer.name !== 'Layer' || (layerFunc && !layerFunc(xmlLayer))) {
+                if (xmlLayer.name() !== 'Layer' || (layerFunc && !layerFunc(xmlLayer))) {
                     return;
                 }
-                let xmlParams = xmlLayer.childNamed('Datasource');
+                let xmlParams = xmlLayer.get('Datasource');
                 if (!xmlParams) {
                     self._log('warn', '<Datasource> xml element was not found in layer %j in %j',
-                        xmlLayer.attr.name, xmlFile);
+                        xmlLayer.attr('name').value(), xmlFile);
                     return;
                 }
                 if (conditions) {
                     if (!_.all(conditions, (val, key) =>
-                        self._xmlParamByName(xmlParams, key, xmlFile).val === val)
+                        self._xmlParamByName(doc, xmlParams, key, xmlFile).text(val))
                     ) {
                         return;
                     }
                 }
-                self._log('trace', 'Updating layer ' + xmlLayer.attr.name);
+                self._log('trace', 'Updating layer ' + xmlLayer.attr('name').value());
                 checkType(ds, 'set', 'object', true);
-                self._setXmlParameters(ds.set, xmlParams, xmlFile);
+                self._setXmlParameters(doc, ds.set, xmlParams, xmlFile);
             });
         });
     }
@@ -160,14 +157,15 @@ XmlLoader.prototype.update = function update(xmlData, xmlFile) {
  * @param {boolean} [createIfMissing]
  * @private
  */
-XmlLoader.prototype._xmlParamByName = function(xmlParams, name, xmlFile, createIfMissing) {
-    let param = xmlParams.childWithAttribute('name', name);
-    if (!param || param.name !== 'Parameter') {
+XmlLoader.prototype._xmlParamByName = function(doc, xmlParams, name, xmlFile, createIfMissing) {
+    let param = xmlParams.get(`*[@name='${name}']`);
+    if (!param || param.name() !== 'Parameter') {
         if (!createIfMissing) {
             throw new Err('<Parameter name=%j> xml element was not found in %j', name, xmlFile);
         }
-        param = new xmldoc.XmlDocument(`<Parameter name="${name}" />`);
-        xmlParams.children.push(param);
+        param = new libxmljs.Element(doc, 'Parameter');
+        param.attr({name});
+        xmlParams.addChild(param);
     }
     return param;
 };
@@ -175,15 +173,17 @@ XmlLoader.prototype._xmlParamByName = function(xmlParams, name, xmlFile, createI
 XmlLoader.prototype._setXmlAttributes = function(newValues, xmlElement) {
     let self = this;
     _.each(newValues, (value, name) => {
-        xmlElement.attr[name] = self._resolveValue(value, name);
+        const attr = {};
+        attr[name] = self._resolveValue(value, name);
+        xmlElement.attr(attr);
     });
 };
 
-XmlLoader.prototype._setXmlParameters = function(newValues, xmlParams, xmlFile) {
+XmlLoader.prototype._setXmlParameters = function(doc, newValues, xmlParams, xmlFile) {
     let self = this;
     _.each(newValues, (value, name) => {
-        let param = self._xmlParamByName(xmlParams, name, xmlFile, true);
-        param.val = self._resolveValue(value, name);
+        let param = self._xmlParamByName(doc, xmlParams, name, xmlFile, true);
+        param.text(self._resolveValue(value, name));
     });
 };
 
@@ -202,5 +202,5 @@ function getLayerFilter(opts) {
         throw new Err(
             'XmlLoader xmlLayers/xmlExceptLayers must be a string or an array of strings');
     }
-    return xmlChild => _.contains(layers, xmlChild.attr.name) === include;
+    return xmlChild => _.contains(layers, xmlChild.attr('name').value()) === include;
 }

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "access": "public"
   },
   "dependencies": {
+    "@kartotherian/err": "^0.0.3",
+    "@kartotherian/input-validator": "^0.0.6",
     "bluebird": "^3.5.0",
     "js-yaml": "^3.8.2",
-    "underscore": "^1.8.3",
-    "xmldoc": "git+https://github.com/nyurik/xmldoc.git",
-    "@kartotherian/err": "^0.0.3",
-    "@kartotherian/input-validator": "^0.0.6"
+    "libxmljs": "^0.19.1",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "mocha": "^5.2.0"

--- a/test/xmlLoaderTest.js
+++ b/test/xmlLoaderTest.js
@@ -17,22 +17,13 @@ function xml(opts) {
     if (opts.source === undefined){
         opts.source = '<![CDATA[<a/>]]>';
     }
-    const source = !opts.source ? '' : `\n    <Parameter name="source">${opts.source}</Parameter>`;
+    const source = !opts.source ? '' : `<Parameter name="source">${opts.source}</Parameter>`;
 
-    const layerOptional = opts.excludeOptional ? '' : `
-  <Layer name="layerOptional">
-    <StyleName>Optional</StyleName>
-  </Layer>`;
+    const layerOptional = opts.excludeOptional ? '' : `<Layer name="layerOptional"><StyleName>Optional</StyleName></Layer>`;
 
-    // `<?xml version="1.0" encoding="utf-8"?><!DOCTYPE Map[]>
-    return `<Map srs="abc"${opts.attrs || ''}>
-  <Parameters>
-    <Parameter name="attribution"><![CDATA[<a/>]]></Parameter>${source}
-  </Parameters>
-  <Layer name="layerAlways">
-    <StyleName>Always</StyleName>
-  </Layer>${layerOptional}
-</Map>`;
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<Map srs="abc"${opts.attrs || ''}><Parameters><Parameter name="attribution"><![CDATA[<a/>]]></Parameter>${source}</Parameters><Layer name="layerAlways"><StyleName>Always</StyleName></Layer>${layerOptional}</Map>
+`;
 }
 
 describe('xmlLoader', () => {


### PR DESCRIPTION
The *Loader classes in module-loader expose an update() method for updating
the internal representation of a parsed XML or YAML file and returning the
result as an XML or YAML string. xmldoc, which the XmlLoader class uses to
parse XML docs, doesn't appear to be designed for manipulating parsed XML,
but only for reading it, and its XMLDocument and XMLElement classes don't
provide any public interface for updating their contents. This is currently
worked around by manipulating the 'val' property of xmldoc XMLElement
objects of interest.[1]

This commit updates XmlLoader to use libxmljs, which provides a proper
interface for manipulating XML Document objects. This allows us to move
off our specialized xmldoc fork and makes us more robust going forward.

Phab: https://phabricator.wikimedia.org/T177019